### PR TITLE
Mercurial Dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,5 +10,8 @@
 
 class vim {
   require vim::setup
-  package { 'vim': }
+  package { 'mercurial': }
+  package { 'vim':
+    require => Package['mercurial']
+  }
 }


### PR DESCRIPTION
the homebrew formula for vim uses hg instead of git and thus without mercurial installed, the vim package fails to execute successfully. This pull request introduces a dependency on the mercurial homebrew package to resolve this issue.
