### PR TITLE
Remove necessity for loader injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,19 @@ This package won't interfere the puppet-macvim package. Please note that you __m
 The following example will install vim, pathogen and the vim_bundle you specify in your ~/.vim/bundle directory
 
     include vim
-    vim::bundle { 'scrooloose/syntastic': }
-    vim::bundle { 'sjl/gundo.vim: }
+    vim::bundle { [
+      'scrooloose/syntastic',
+      'sjl/gundo.vim'
+    ]: }
 
     # Example of how you can manage your .vimrc
-    file { "/Users/${::boxen_user}/.vimrc":
+    file { "${vim::vimrc}":
       target  => "/Users/${::boxen_user}/.dotfiles/.vimrc",
       require => Repository["/Users/${::boxen_user}/.dotfiles"]
     }
+
+    # Or, simply,
+    file { "${vim::vimrc}": ensure => exists }
 
 ## Required Puppet Modules
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,17 @@
 # Installs vim and vim-pathogen
-# This class require that you're .vimrc is managed by puppet
 
 # Examples
 #
 #   include vim
+#   vim::loader
 #   vim::bundle { 'syntastic':
 #     source => 'scrooloose/syntastic',
 #   }
 #
 class vim {
+  $home = "/Users/${::boxen_user}"
+  $vimrc = "${home}/.vimrc"
+  $vimdir = "${home}/.vim"
 
   package { 'vim':
     require => Package['mercurial']
@@ -16,32 +19,24 @@ class vim {
   # Install mercurial since the vim brew package don't satisfy the requirement
   package { 'mercurial': }
 
-  file { ["/Users/${::boxen_user}/.vim",
-    "/Users/${::boxen_user}/.vim/autoload",
-    "/Users/${::boxen_user}/.vim/bundle"]:
+  file { ["${vimdir}",
+    "${vimdir}/autoload",
+    "${vimdir}/bundle"]:
     ensure  => directory,
     recurse => true,
   }
 
-  repository { "/Users/${::boxen_user}/.vim/vim-pathogen":
+  repository { "${vimdir}/vim-pathogen":
     source => 'tpope/vim-pathogen'
   }
 
-  file { "/Users/${::boxen_user}/.vim/autoload/pathogen.vim":
-    target  => "/Users/${::boxen_user}/.vim/vim-pathogen/autoload/pathogen.vim",
+  file { "${vimdir}/autoload/pathogen.vim":
+    target  => "${vimdir}/vim-pathogen/autoload/pathogen.vim",
     require => [
-      File["/Users/${::boxen_user}/.vim"],
-      File["/Users/${::boxen_user}/.vim/autoload"],
-      File["/Users/${::boxen_user}/.vim/bundle"],
-      Repository["/Users/${::boxen_user}/.vim/vim-pathogen"]
+      File["${vimdir}"],
+      File["${vimdir}/autoload"],
+      File["${vimdir}/bundle"],
+      Repository["${vimdir}/vim-pathogen"]
     ]
-  }
-
-  # Install pathogen into .vimrc
-  file_line { 'load_pathogen':
-    ensure  => present,
-    line    => 'execute pathogen#infect()',
-    path    => "/Users/${::boxen_user}/.vimrc",
-    require => File["/Users/${::boxen_user}/.vimrc"]
   }
 }

--- a/manifests/loader.pp
+++ b/manifests/loader.pp
@@ -1,0 +1,21 @@
+# Adds the pathogen loader line to your vim config
+
+# This class requires your vimrc to be managed by puppet
+#   (IE: the File[/Users/.../.vimrc] resource must exist)
+
+# Examples
+#
+#   include vim
+#   vim::loader
+
+class vim::loader {
+  require vim
+
+  # Install pathogen into .vimrc
+  file_line { 'load_pathogen':
+    ensure  => present,
+    line    => 'execute pathogen#infect()',
+    path    => "${vim::vimrc}",
+    require => File["${vim::vimrc}"]
+  }
+}


### PR DESCRIPTION
https://github.com/boxen/puppet-vim/issues/9

I had a similar issue as I would really much rather have my vimrc be symlinked to my dotfiles repository so I can more easily track changes. This splits the logic so it can be called individually if necessary.
